### PR TITLE
bug: 학생 연속 수정 시 세션 값 변경 되지 않는 버그 해결

### DIFF
--- a/src/main/java/com/time/studentmanage/service/StudentService.java
+++ b/src/main/java/com/time/studentmanage/service/StudentService.java
@@ -66,7 +66,7 @@ public class StudentService {
     }
 
     // 학생_정보_수정
-    public StudentRespDto updateStudentInfo(Long id, StudentUpdateReqDto updateReqDto) {
+    public Student updateStudentInfo(Long id, StudentUpdateReqDto updateReqDto) {
         Optional<Student> studentOP = studentRepository.findById(id);
 
         if (!studentOP.isPresent()) {
@@ -76,7 +76,7 @@ public class StudentService {
         Student student = studentOP.get();
         student.changeEntity(id, updateReqDto.toEntity());
 
-        return new StudentRespDto(student);
+        return student;
     }
 
     //학생_재원여부_변경

--- a/src/main/java/com/time/studentmanage/service/TeacherService.java
+++ b/src/main/java/com/time/studentmanage/service/TeacherService.java
@@ -44,7 +44,7 @@ public class TeacherService {
     }
     
     // 선생_정보_수정
-    public TeacherRespDto updateTeacherInfo(Long id, TeacherUpdateReqDto updateReqDto) {
+    public Teacher updateTeacherInfo(Long id, TeacherUpdateReqDto updateReqDto) {
         Optional<Teacher> teacherOP = teacherRepository.findById(id);
         if (!teacherOP.isPresent()) {
             throw new DataNotFoundException("존재하지 않는 ID입니다.");
@@ -54,7 +54,7 @@ public class TeacherService {
         teacher.changeEntity(id, updateReqDto.toEntity());
 
 
-        return new TeacherRespDto(teacher);
+        return teacher;
     }
 
     //선생_비밀번호_수정

--- a/src/main/java/com/time/studentmanage/web/student/StudentController.java
+++ b/src/main/java/com/time/studentmanage/web/student/StudentController.java
@@ -113,7 +113,7 @@ public class StudentController {
         log.info("studentUpdateReqDto 체크={}", studentUpdateReqDto);
 
         // edit
-        StudentRespDto updateStudent = studentService.updateStudentInfo(studentUpdateReqDto.getId(), studentUpdateReqDto);
+        Student updateStudent = studentService.updateStudentInfo(studentUpdateReqDto.getId(), studentUpdateReqDto);
 
         //선생이 학생 정보 수정 시 세션 변경X
         if (sessionObject.getClass().equals(Student.class)) {

--- a/src/main/java/com/time/studentmanage/web/teacher/TeacherController.java
+++ b/src/main/java/com/time/studentmanage/web/teacher/TeacherController.java
@@ -109,7 +109,7 @@ public class TeacherController {
             return "teacher/teacher_edit_form";
         }
         //선생 정보 수정
-        TeacherRespDto teacher = teacherService.updateTeacherInfo(id, teacherUpdateReqDto);
+        Teacher teacher = teacherService.updateTeacherInfo(id, teacherUpdateReqDto);
 
         //세션에 저장된 선생 정보
         Teacher loginTeacher = (Teacher) session.getAttribute(SessionConst.LOGIN_MEMBER_SESSION);


### PR DESCRIPTION
RespDTO로 세션에 저장하지 않고, 엔티티로 저장.

처음 로그인 시 학생, 선생 자체 객체가 담겨 있어서 로직 변경이 어려워 엔티티로 저장하는 것으로 통일.

close #79 
